### PR TITLE
Add explicit compressioninfo when writing file to zip

### DIFF
--- a/SharpCompress/SharpCompress.Portable.csproj
+++ b/SharpCompress/SharpCompress.Portable.csproj
@@ -321,6 +321,7 @@
     <Compile Include="Writer\Tar\TarWriter.cs" />
     <Compile Include="Writer\WriterFactory.cs" />
     <Compile Include="Writer\Zip\ZipCentralDirectoryEntry.cs" />
+    <Compile Include="Writer\Zip\ZipCompressionInfo.cs" />
     <Compile Include="Writer\Zip\ZipWriter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpCompress/SharpCompress.PortableTest.csproj
+++ b/SharpCompress/SharpCompress.PortableTest.csproj
@@ -371,6 +371,7 @@
     <Compile Include="Writer\Tar\TarWriter.cs" />
     <Compile Include="Writer\WriterFactory.cs" />
     <Compile Include="Writer\Zip\ZipCentralDirectoryEntry.cs" />
+    <Compile Include="Writer\Zip\ZipCompressionInfo.cs" />
     <Compile Include="Writer\Zip\ZipWriter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpCompress/SharpCompress.Unsigned.csproj
+++ b/SharpCompress/SharpCompress.Unsigned.csproj
@@ -359,6 +359,7 @@
     <Compile Include="Writer\Tar\TarWriter.cs" />
     <Compile Include="Writer\WriterFactory.cs" />
     <Compile Include="Writer\Zip\ZipCentralDirectoryEntry.cs" />
+    <Compile Include="Writer\Zip\ZipCompressionInfo.cs" />
     <Compile Include="Writer\Zip\ZipWriter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpCompress/SharpCompress.WindowsStore.csproj
+++ b/SharpCompress/SharpCompress.WindowsStore.csproj
@@ -306,6 +306,7 @@
     <Compile Include="Writer\Tar\TarWriter.cs" />
     <Compile Include="Writer\WriterFactory.cs" />
     <Compile Include="Writer\Zip\ZipCentralDirectoryEntry.cs" />
+    <Compile Include="Writer\Zip\ZipCompressionInfo.cs" />
     <Compile Include="Writer\Zip\ZipWriter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpCompress/SharpCompress.csproj
+++ b/SharpCompress/SharpCompress.csproj
@@ -359,6 +359,7 @@
     <Compile Include="Writer\Tar\TarWriter.cs" />
     <Compile Include="Writer\WriterFactory.cs" />
     <Compile Include="Writer\Zip\ZipCentralDirectoryEntry.cs" />
+    <Compile Include="Writer\Zip\ZipCompressionInfo.cs" />
     <Compile Include="Writer\Zip\ZipWriter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpCompress/Writer/Zip/ZipCompressionInfo.cs
+++ b/SharpCompress/Writer/Zip/ZipCompressionInfo.cs
@@ -1,0 +1,47 @@
+﻿using SharpCompress.Common;
+using SharpCompress.Common.Zip;
+using SharpCompress.Compressor.Deflate;
+
+namespace SharpCompress.Writer.Zip
+{
+    internal class ZipCompressionInfo
+    {
+        internal CompressionLevel DeflateCompressionLevel { get; private set; }
+        internal ZipCompressionMethod Compression { get; private set; }
+
+        public ZipCompressionInfo(CompressionInfo compressionInfo)
+        {
+            switch (compressionInfo.Type)
+            {
+                case CompressionType.None:
+                    {
+                        this.Compression = ZipCompressionMethod.None;
+                    }
+                    break;
+                case CompressionType.Deflate:
+                    {
+                        this.DeflateCompressionLevel = compressionInfo.DeflateCompressionLevel;
+                        this.Compression = ZipCompressionMethod.Deflate;
+                    }
+                    break;
+                case CompressionType.BZip2:
+                    {
+                        this.Compression = ZipCompressionMethod.BZip2;
+                    }
+                    break;
+                case CompressionType.LZMA:
+                    {
+                        this.Compression = ZipCompressionMethod.LZMA;
+                    }
+                    break;
+                case CompressionType.PPMd:
+                    {
+                        this.Compression = ZipCompressionMethod.PPMd;
+                    }
+                    break;
+                default:
+                    throw new InvalidFormatException("Invalid compression method: " + compressionInfo.Type);
+            }
+        }
+    }
+}

--- a/SharpCompress/Writer/Zip/ZipWriter.cs
+++ b/SharpCompress/Writer/Zip/ZipWriter.cs
@@ -17,52 +17,18 @@ namespace SharpCompress.Writer.Zip
 {
     public class ZipWriter : AbstractWriter
     {
-        private readonly ZipCompressionMethod compression;
-        private readonly CompressionLevel deflateCompressionLevel;
-
+        private readonly ZipCompressionInfo zipCompressionInfo;
+        private readonly PpmdProperties ppmdProperties = new PpmdProperties(); // Caching properties to speed up PPMd
         private readonly List<ZipCentralDirectoryEntry> entries = new List<ZipCentralDirectoryEntry>();
         private readonly string zipComment;
         private long streamPosition;
-
-        private readonly PpmdProperties ppmdProperties; // Caching properties to speed up PPMd.
 
         public ZipWriter(Stream destination, CompressionInfo compressionInfo, string zipComment)
             : base(ArchiveType.Zip)
         {
             this.zipComment = zipComment ?? string.Empty;
 
-            switch (compressionInfo.Type)
-            {
-                case CompressionType.None:
-                    {
-                        compression = ZipCompressionMethod.None;
-                    }
-                    break;
-                case CompressionType.Deflate:
-                    {
-                        compression = ZipCompressionMethod.Deflate;
-                        deflateCompressionLevel = compressionInfo.DeflateCompressionLevel;
-                    }
-                    break;
-                case CompressionType.BZip2:
-                    {
-                        compression = ZipCompressionMethod.BZip2;
-                    }
-                    break;
-                case CompressionType.LZMA:
-                    {
-                        compression = ZipCompressionMethod.LZMA;
-                    }
-                    break;
-                case CompressionType.PPMd:
-                    {
-                        ppmdProperties = new PpmdProperties();
-                        compression = ZipCompressionMethod.PPMd;
-                    }
-                    break;
-                default:
-                    throw new InvalidFormatException("Invalid compression method: " + compressionInfo.Type);
-            }
+            this.zipCompressionInfo = new ZipCompressionInfo(compressionInfo);
             InitalizeStream(destination, false);
         }
 
@@ -73,7 +39,7 @@ namespace SharpCompress.Writer.Zip
                 uint size = 0;
                 foreach (ZipCentralDirectoryEntry entry in entries)
                 {
-                    size += entry.Write(OutputStream, compression);
+                    size += entry.Write(OutputStream, zipCompressionInfo.Compression);
                 }
                 WriteEndRecord(size);
             }
@@ -85,15 +51,15 @@ namespace SharpCompress.Writer.Zip
             Write(entryPath, source, modificationTime, null);
         }
 
-        public void Write(string entryPath, Stream source, DateTime? modificationTime, string comment)
+        public void Write(string entryPath, Stream source, DateTime? modificationTime, string comment, CompressionInfo compressionInfo = null)
         {
-            using (Stream output = WriteToStream(entryPath, modificationTime, comment))
+            using (Stream output = WriteToStream(entryPath, modificationTime, comment, compressionInfo))
             {
                 source.TransferTo(output);
             }
         }
 
-        public Stream WriteToStream(string entryPath, DateTime? modificationTime, string comment)
+        public Stream WriteToStream(string entryPath, DateTime? modificationTime, string comment, CompressionInfo compressionInfo = null)
         {
             entryPath = NormalizeFilename(entryPath);
             modificationTime = modificationTime ?? DateTime.Now;
@@ -105,7 +71,8 @@ namespace SharpCompress.Writer.Zip
                                 ModificationTime = modificationTime,
                                 HeaderOffset = (uint) streamPosition,
                             };
-            var headersize = (uint) WriteHeader(entryPath, modificationTime);
+
+            var headersize = (uint)WriteHeader(entryPath, modificationTime, compressionInfo);
             streamPosition += headersize;
             return new ZipWritingStream(this, OutputStream, entry);
         }
@@ -121,12 +88,13 @@ namespace SharpCompress.Writer.Zip
             return filename.Trim('/');
         }
 
-        private int WriteHeader(string filename, DateTime? modificationTime)
+        private int WriteHeader(string filename, DateTime? modificationTime, CompressionInfo compressionInfo = null)
         {
+            var explicitZipCompressionInfo = compressionInfo != null ? new ZipCompressionInfo(compressionInfo) : this.zipCompressionInfo;
             byte[] encodedFilename = ArchiveEncoding.Default.GetBytes(filename);
 
             OutputStream.Write(BitConverter.GetBytes(ZipHeaderFactory.ENTRY_HEADER_BYTES), 0, 4);
-            if (compression != ZipCompressionMethod.Deflate)
+            if (explicitZipCompressionInfo.Compression != ZipCompressionMethod.Deflate)
             {
                 OutputStream.Write(new byte[] {63, 0}, 0, 2); //version
             }
@@ -138,13 +106,13 @@ namespace SharpCompress.Writer.Zip
             if (!OutputStream.CanSeek)
             {
                 flags |= HeaderFlags.UsePostDataDescriptor;
-                if (compression == ZipCompressionMethod.LZMA)
+                if (explicitZipCompressionInfo.Compression == ZipCompressionMethod.LZMA)
                 {
                     flags |= HeaderFlags.Bit1; // eos marker
                 }
             }
             OutputStream.Write(BitConverter.GetBytes((ushort) flags), 0, 2);
-            OutputStream.Write(BitConverter.GetBytes((ushort) compression), 0, 2); // zipping method
+            OutputStream.Write(BitConverter.GetBytes((ushort)explicitZipCompressionInfo.Compression), 0, 2); // zipping method
             OutputStream.Write(BitConverter.GetBytes(modificationTime.DateTimeToDosTime()), 0, 4);
             // zipping date and time
             OutputStream.Write(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, 12);
@@ -227,7 +195,7 @@ namespace SharpCompress.Writer.Zip
             {
                 counting = new CountingWritableSubStream(writeStream);
                 Stream output = counting;
-                switch (writer.compression)
+                switch (writer.zipCompressionInfo.Compression)
                 {
                     case ZipCompressionMethod.None:
                         {
@@ -235,7 +203,7 @@ namespace SharpCompress.Writer.Zip
                         }
                     case ZipCompressionMethod.Deflate:
                         {
-                            return new DeflateStream(counting, CompressionMode.Compress, writer.deflateCompressionLevel,
+                            return new DeflateStream(counting, CompressionMode.Compress, writer.zipCompressionInfo.DeflateCompressionLevel,
                                                      true);
                         }
                     case ZipCompressionMethod.BZip2:
@@ -261,7 +229,7 @@ namespace SharpCompress.Writer.Zip
                         }
                     default:
                         {
-                            throw new NotSupportedException("CompressionMethod: " + writer.compression);
+                            throw new NotSupportedException("CompressionMethod: " + writer.zipCompressionInfo.Compression);
                         }
                 }
             }


### PR DESCRIPTION
The default Mac UI unzipping (double click on the zip file) is throwing "Unable to expand. Error 2 No such file or directory." if there is an empty file in the archive. 

As this is not a general bug, but one tool issue, the solution for me is to provide the API with option to explicitly change the compression info for specific files. This way if there are empty files or other specifics one can have different compression infos in one archive.

Still, I am looking for opinions whether this is the right approach and if so, is it enough to have it implemented only in ZipWriter or have it for all IWriters?

ping @zahhak @ligaz @vanka78bg @Icenium/core 

affects https://github.com/Icenium/Ice/pull/4391
